### PR TITLE
Feature/repo security scanner

### DIFF
--- a/repo-security-scanner.rb
+++ b/repo-security-scanner.rb
@@ -1,0 +1,36 @@
+require "language/go"
+
+class RepoSecurityScanner < Formula
+  desc "CLI tool that finds secrets accidentally committed to a git repo, eg passwords, private keys"
+  homepage "https://github.com/UKHomeOffice/repo-security-scanner"
+  version "0.3.1"
+
+  depends_on "cmake" => :build
+  depends_on "go@1.9" => :build
+
+  url "https://github.com/UKHomeOffice/repo-security-scanner.git",
+    :revision => "13b8368c2df5b49dcbfa21c4a81986486ea5f7e4"
+
+  head "https://github.com/UKHomeOffice/repo-security-scanner.git",
+   :shallow => false
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GITHUB_WEBHOOKSECRET"]
+    ENV.prepend_create_path "PATH", "#{buildpath}/bin"
+    dir = "#{buildpath}/src/github.com/UKHomeOffice/repo-security-scanner"
+    dir.install buildpath.children - ["#{buildpath}/.brew_home"]
+
+    cd dir do
+      system "make", "deps"
+      system "go", "get", "-v"
+      system "make", "cli"
+      bin.install "#{buildpath}/bin/scanrepo"
+    end
+
+  end
+
+  test do
+    system "scanrepo", "--help"
+  end
+end

--- a/repo-security-scanner.rb
+++ b/repo-security-scanner.rb
@@ -32,4 +32,11 @@ class RepoSecurityScanner < Formula
   test do
     system "scanrepo", "--help"
   end
+
+  def caveats
+    """
+Usage:
+    git log -p | scanrepo
+"""
+  end
 end

--- a/repo-security-scanner.rb
+++ b/repo-security-scanner.rb
@@ -16,11 +16,10 @@ class RepoSecurityScanner < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GITHUB_WEBHOOKSECRET"]
-    ENV.prepend_create_path "PATH", "#{buildpath}/bin"
-    dir = "#{buildpath}/src/github.com/UKHomeOffice/repo-security-scanner"
-    dir.install buildpath.children - ["#{buildpath}/.brew_home"]
-
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    dir = buildpath/"src/github.com/UKHomeOffice/repo-security-scanner"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+    
     cd dir do
       system "make", "deps"
       system "go", "get", "-v"


### PR DESCRIPTION
Add a homebrew formula for [https://github.com/UKHomeOffice/repo-security-scanner](https://github.com/UKHomeOffice/repo-security-scanner).

This is currently pinned to 0.3.1, as the 0.4.0 release throws an error

```# github.com/UKHomeOffice/repo-security-scanner/cmd/scanrepo
cmd/scanrepo/main.go:60:23: undefined: diffence.SplitDiffHashKey
make: *** [cli] Error 2```