### PR TITLE
Fixed bad hash

### DIFF
--- a/go-gocd.rb
+++ b/go-gocd.rb
@@ -3,7 +3,7 @@ class GoGocd < Formula
   homepage "https://github.com/beamly/terraform-provider-gocd"
   url "https://github.com/beamly/go-gocd/releases/download/0.6.16/gocd-0.6.16-darwin-x86_64.zip"
   version "0.6.16"
-  sha256 "c9fe2e772e3ed08a9007c28abfcdd5615c4713bb8e9e6c296f7d55017e912720"
+  sha256 "291d65170e756b26b932e87a0f7c95ac10c6a22d4a49d1c8714f50efc17a6d29"
   
   depends_on "drewsonne/homebrew-tap/tf-install-provider"
 


### PR DESCRIPTION
When installing or upgrading go-gocd the following error would be thrown. This fixes that error.
```
$ brew upgrade go-gocd
...
==> Upgrading 1 outdated package, with result:
beamly/tap/go-gocd 0.6.14 -> 0.6.16
==> Upgrading beamly/tap/go-gocd
==> Downloading https://github.com/beamly/go-gocd/releases/download/0.6.16/gocd-0.6.16-darwin-x86_64.zip
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/97909208/0ff16fd0-3eeb-11e8-990b-581dbc8fe45b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20180517%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180517T0930
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: c9fe2e772e3ed08a9007c28abfcdd5615c4713bb8e9e6c296f7d55017e912720
Actual: 291d65170e756b26b932e87a0f7c95ac10c6a22d4a49d1c8714f50efc17a6d29
Archive: /Users/drew.sonne/Library/Caches/Homebrew/go-gocd-0.6.16.zip
To retry an incomplete download, remove the file above.
```